### PR TITLE
Support setting the handshake while running commands from a file.

### DIFF
--- a/file.go
+++ b/file.go
@@ -69,6 +69,9 @@ func executeCommand(logger Log, command string) error {
 			wait.Done()
 		})
 
+	case "sethandshake":
+		return setHandshake(logger, parts[1:])
+
 	case "request":
 		wait.Add(1)
 		if err := request(logger, parts[1:]); err != nil {

--- a/shell.go
+++ b/shell.go
@@ -118,7 +118,7 @@ func registerSetHandshake(shell *ishell.Shell) {
 		Name: "sethandshake",
 		Help: "sets a handshake parameter",
 		Func: func(c *ishell.Context) {
-			err := setHandshake(c, c.Args)
+			err := setHandshake(c, c.RawArgs[1:])
 			if err != nil {
 				c.Err(err)
 			}


### PR DESCRIPTION
I am trying to run a test scenario from a file (`pitaya-cli -filename <somefile>`) like:
```
sethandshake platform android
sethandshake version 3.0.2
sethandshake buildNumber 2786
sethandshake version 1.20.0
connect pitaya-server.com:3250
request metagame.handker.authenticate {}
disconnect
```
and I am getting:
```
2020/07/15 19:37:26 error: command not found
```
because `sethandshake` is not supported while reading commands from a file.
