### PR TITLE
Fix how parameters are given to the request function

### DIFF
--- a/shell.go
+++ b/shell.go
@@ -82,7 +82,7 @@ func registerRequest(shell *ishell.Shell) {
 		Name: "request",
 		Help: "makes a request to pitaya server",
 		Func: func(c *ishell.Context) {
-			err := request(c, c.RawArgs[1:])
+			err := request(c, c.Args)
 			if err != nil {
 				c.Err(err)
 			}


### PR DESCRIPTION
### What does this PR do?

Fix how messages are sent to server using the `request` function.
It was stripping some spaces in messages:
```go
// call
request pitaya.route "{ \"test\": \"my test\" }"

// message received
"{ \"test\":\"mytest\"}"
```